### PR TITLE
Let users on rota editing account view rota vacancies

### DIFF
--- a/toolkit/diary/edit_views.py
+++ b/toolkit/diary/edit_views.py
@@ -699,7 +699,7 @@ def printed_programme_edit(request, operation):
     return render(request, 'form_printedprogramme_archive.html', context)
 
 
-@permission_required('toolkit.read')
+@permission_required('diary.change_rotaentry')
 def view_rota_vacancies(request):
     days_ahead = 6
     start = timezone.now()


### PR DESCRIPTION
Currently the toolkit allows a user who has logged in with the 'volunteer' account to view and edit the rota but not view the easy-email vacancy list. I didn't think this made much sense
